### PR TITLE
[EV-1171][EV-1173] Update dependencies to support special transactions for 0.13 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dashevo/dashcore-lib": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-0.15.5.tgz",
-      "integrity": "sha512-tV5PgQYLMWO3A3I2Q5wN6KKjedlnr1DtFWp1oIufgIKQf3F0bjSWol2+kujy9l7AbeshyO7WHLXvfP8qIJSKjA==",
+      "version": "1.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-1.0.0-alpha.19.tgz",
+      "integrity": "sha512-pT6c4E+t/5Mubf+Ai0iqzQqLpqVTgUp3fZqI+fhyCW7qBfmZay08mNpFD+7IQTXEWpqs8QpBRTHrWmzYirLREQ==",
       "requires": {
         "@dashevo/x11-hash-js": "^1.0.2",
         "bn.js": "=2.0.4",
@@ -15,8 +15,16 @@
         "buffer-compare": "=1.0.0",
         "elliptic": "=3.0.3",
         "inherits": "=2.0.1",
-        "lodash": "=4.17.1",
-        "sha512": "=0.0.1"
+        "lodash": "^4.17.11",
+        "sha512": "=0.0.1",
+        "unorm": "^1.3.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+        }
       }
     },
     "@dashevo/dashcore-p2p": {
@@ -32,11 +40,12 @@
       }
     },
     "@dashevo/dashd-rpc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-1.0.1.tgz",
-      "integrity": "sha512-iltJCCcE/NL82CKb57pSe+bqoMFf0ZjtOfazwWk96n3ko3/OUxKUeH+94ABRADQfX05iQlU5TZvGoAqz6I+oNg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-1.2.1.tgz",
+      "integrity": "sha512-SlJblpyw0lduHtXcIu0VVRElwY2zco+DGPUSKq4pn/DclDnklrU91sDwq1LyhJwqTk8UdMuF1jr/rlYynrVYqQ==",
       "requires": {
-        "async": "^1.3.0"
+        "async": "^1.3.0",
+        "bluebird": "^3.5.1"
       }
     },
     "@dashevo/x11-hash-js": {
@@ -336,6 +345,11 @@
       "resolved": "https://registry.npmjs.org/bloom-filter/-/bloom-filter-0.2.0.tgz",
       "integrity": "sha1-hNY7v5Fy2DA+ZMH/FuudvzOpgaM=",
       "dev": true
+    },
+    "bluebird": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "bn.js": {
       "version": "2.0.4",
@@ -2218,7 +2232,8 @@
     "lodash": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.1.tgz",
-      "integrity": "sha1-516vF6NHMMZJHZlW9NgfOgRPAb8="
+      "integrity": "sha1-516vF6NHMMZJHZlW9NgfOgRPAb8=",
+      "dev": true
     },
     "log-driver": {
       "version": "1.2.5",
@@ -3631,6 +3646,11 @@
           }
         }
       }
+    },
+    "unorm": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+      "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "dashd"
   ],
   "dependencies": {
-    "@dashevo/dashcore-lib": "^0.15.5",
-    "@dashevo/dashd-rpc": "^1.0.1",
+    "@dashevo/dashcore-lib": "^1.0.0-alpha.19",
+    "@dashevo/dashd-rpc": "^1.2.1",
     "async": "^1.3.0",
     "body-parser": "^1.13.3",
     "colors": "^1.1.2",


### PR DESCRIPTION
**Issue being fixed or implemented**
Special transactions in blocks are crashing Insight. Updating the dependencies to the latest version of of @dashevo/dashcore-lib and @dashevo/dashd-rpc should take care of this.
**What was done**
updated above dependencies in package.json
**What has been tested**
tested on a testnet standalone server installation
**What needs to be tested**
n/a
**Code Coverage**
n/a