### PR TITLE
[EV-1171][EV-1195] Update dependency of dashcore-lib to new prerelease 1.0.0-alpha.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@dashevo/dashcore-lib": {
-      "version": "1.0.0-alpha.19",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-1.0.0-alpha.19.tgz",
-      "integrity": "sha512-pT6c4E+t/5Mubf+Ai0iqzQqLpqVTgUp3fZqI+fhyCW7qBfmZay08mNpFD+7IQTXEWpqs8QpBRTHrWmzYirLREQ==",
+      "version": "1.0.0-alpha.22",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashcore-lib/-/dashcore-lib-1.0.0-alpha.22.tgz",
+      "integrity": "sha512-LMggcx/b8gG9E1y1ar88Ah+nzVhcsVZJplqbcO4oDsrPtlzCyPp4vmAU6StzhWO0+KaZu7NC4I+oG1G0Mx7piw==",
       "requires": {
         "@dashevo/x11-hash-js": "^1.0.2",
         "bn.js": "=2.0.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "dashd"
   ],
   "dependencies": {
-    "@dashevo/dashcore-lib": "^1.0.0-alpha.19",
+    "@dashevo/dashcore-lib": "^1.0.0-alpha.22",
     "@dashevo/dashd-rpc": "^1.2.1",
     "async": "^1.3.0",
     "body-parser": "^1.13.3",


### PR DESCRIPTION
**Issue being fixed or implemented**
This is for the imminent 13.0 mainnet launch. Updated dependency of dashcore-lib to new prerelease 1.0.0-alpha.2
**What was done**
as above
**What has been tested**
unit tests
**What needs to be tested**
will test this develop version on insight api testnet install. Once deemed stable will bump major version, push git tag, push to master and make new npm release 5.0.0
**Code Coverage**
n/a