### PR TITLE
Pass through DIP2 extra payloads in getDetailedTransaction

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -23,7 +23,7 @@
   "undef": true,
   "unused": true,
   "maxparams": 4,
-  "maxstatements": 16,
+  "maxstatements": 17,
   "maxcomplexity": 10,
   "maxdepth": 3,
   "maxlen": 120,

--- a/lib/services/dashd.js
+++ b/lib/services/dashd.js
@@ -2111,6 +2111,34 @@ Dash.prototype.getDetailedTransaction = function(txid, callback) {
     }
   }
 
+  function addExtraPayloadToTx(tx, result) {
+    if (result.version !== 3 || result.type === 0) {
+      return;
+    }
+    tx.type = result.type;
+    tx.extraPayloadSize = result.extraPayloadSize;
+    tx.extraPayload = result.extraPayload;
+
+    if (result.proRegTx !== undefined) {
+      tx.preRegTx = result.preRegTx;
+    }
+    if (result.proUpServTx !== undefined) {
+      tx.proUpServTx = result.proUpServTx;
+    }
+    if (result.proUpRegTx !== undefined) {
+      tx.proUpRegTx = result.proUpRegTx;
+    }
+    if (result.proUpRevTx !== undefined) {
+      tx.proUpRevTx = result.proUpRevTx;
+    }
+    if (result.cbTx !== undefined) {
+      tx.cbTx = result.cbTx;
+    }
+    if (result.qcTx !== undefined) {
+      tx.qcTx = result.qcTx;
+    }
+  }
+
   if (tx) {
     return setImmediate(function() {
       callback(null, tx);
@@ -2138,6 +2166,7 @@ Dash.prototype.getDetailedTransaction = function(txid, callback) {
 
         addInputsToTx(tx, result);
         addOutputsToTx(tx, result);
+        addExtraPayloadToTx(tx, result);
 
         if (!tx.coinbase) {
           tx.feeSatoshis = tx.inputSatoshis - tx.outputSatoshis;


### PR DESCRIPTION
This passes through the `type` field and json formatted extra payload info (e.g. `cbTx`) from raw transactions. Needed in `insight-api`.

I did not add any tests as I'm not very familiar with JS/node/npm development. If someone else would be able to provide these, I'd be very thankful :)