### PR TITLE
Readme: update recommended node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-  - '6'
   - '8'
+  - '10'
 env:
   - CXX=g++-4.8 CC=gcc-4.8
 addons:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ node.on('ready', function() {
 ## Prerequisites
 
 - Dash Core (dashd) (v0.13.0) with support for additional indexing *(see above)*
-- Node.js v6 - v8 (versions higher than v8 are not yet supported)
+- Node.js v8+
 - ZeroMQ *(libzmq3-dev for Ubuntu/Debian or zeromq on OSX)*
 - ~20GB of disk storage
 - ~1GB of RAM


### PR DESCRIPTION
With the change from zmq to zeromq the library now compiles with node v10. No need to keep v6 methinks. Didn't bump version for this cosmetic change, but if anybody like to bump it go ahead.