### PR TITLE
Remove unused coveralls

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-repo_token: cE3tYE6ZuuPHFa7OTGpb2wqoqaYJ3SLs3

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,3 @@ addons:
 script:
   - npm run test
   - npm run jshint
-after_success:
-  - npm run coveralls


### PR DESCRIPTION
This removes coveralls script in travis.yml and coveralls.yml because coveralls was not set up.