### PR TITLE
fix: hotfix for received rawtxlock message in rawtx topic

### DIFF
--- a/lib/services/dashd.js
+++ b/lib/services/dashd.js
@@ -20,6 +20,7 @@ var errors = index.errors;
 var log = index.log;
 var utils = require('../utils');
 var Service = require('../service');
+var rawtxlockTopicBuffer = new Buffer('72617774786c6f636b', 'hex');
 
 /**
  * Provides a friendly event driven API to dashd in Node.js. Manages starting and
@@ -701,7 +702,11 @@ Dash.prototype._zmqTransactionHandler = function(node, message) {
   }
 };
 
-Dash.prototype._zmqTransactionLockHandler = function(node, message) {
+Dash.prototype._zmqTransactionLockHandler = function (node, message) {
+  if (message === rawtxlockTopicBuffer) {
+    return false;
+  }
+
   var self = this;
   var hash = dashcore.crypto.Hash.sha256sha256(message);
   var id = hash.toString('binary');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

One of the user of insight made a bug report concerning a received `rawtxlock` (`72617774786c6f636b`) message in the subscribed rawtx topic. 
As such input is not expected, the parsing fails warning of the incorrect received buffer. 
While investigations did not answer the inherent reason of such issue, we decided to hotfix it to at least address the problem. 

## What was done?
- provided hotfix that abandon trying to parse such message. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
