### PR TITLE
fix: discarding rawtx topic as transaction

### DIFF
--- a/lib/services/dashd.js
+++ b/lib/services/dashd.js
@@ -21,7 +21,7 @@ var log = index.log;
 var utils = require('../utils');
 var Service = require('../service');
 var rawtxTopicBuffer = new Buffer('7261777478', 'hex');
-
+var rawtxlockTopicBuffer = new Buffer('72617774786c6f636b', 'hex');
 /**
  * Provides a friendly event driven API to dashd in Node.js. Manages starting and
  * stopping dashd as a child process for application support, as well as connecting
@@ -684,7 +684,7 @@ Dash.prototype._notifyAddressTxidSubscribers = function(txid, transaction) {
 Dash.prototype._zmqTransactionHandler = function(node, message) {
   // It happen that ZMQ is throwing 'rawtx'
   // We discard this as they are improper received message from ZMQ.
-  if (message.slice(0, 5).equals(rawtxTopicBuffer)) {
+  if (message.equals(rawtxTopicBuffer)) {
     return false;
   }
   var self = this;
@@ -710,7 +710,7 @@ Dash.prototype._zmqTransactionHandler = function(node, message) {
 Dash.prototype._zmqTransactionLockHandler = function (node, message) {
   // It happen that ZMQ is throwing 'rawtxlock'
   // We discard this as they are improper received message from ZMQ.
-  if (message.slice(0, 5).equals(rawtxTopicBuffer)) {
+  if (message.equals(rawtxlockTopicBuffer)) {
     return false;
   }
 

--- a/lib/services/dashd.js
+++ b/lib/services/dashd.js
@@ -20,7 +20,7 @@ var errors = index.errors;
 var log = index.log;
 var utils = require('../utils');
 var Service = require('../service');
-var rawtxlockTopicBuffer = new Buffer('72617774786c6f636b', 'hex');
+var rawtxTopicBuffer = new Buffer('7261777478', 'hex');
 
 /**
  * Provides a friendly event driven API to dashd in Node.js. Manages starting and
@@ -682,6 +682,11 @@ Dash.prototype._notifyAddressTxidSubscribers = function(txid, transaction) {
 };
 
 Dash.prototype._zmqTransactionHandler = function(node, message) {
+  // It happen that ZMQ is throwing 'rawtx'
+  // We discard this as they are improper received message from ZMQ.
+  if (message.slice(0, 5).equals(rawtxTopicBuffer)) {
+    return false;
+  }
   var self = this;
   var hash = dashcore.crypto.Hash.sha256sha256(message);
   var id = hash.toString('binary');
@@ -703,7 +708,9 @@ Dash.prototype._zmqTransactionHandler = function(node, message) {
 };
 
 Dash.prototype._zmqTransactionLockHandler = function (node, message) {
-  if (message === rawtxlockTopicBuffer) {
+  // It happen that ZMQ is throwing 'rawtxlock'
+  // We discard this as they are improper received message from ZMQ.
+  if (message.slice(0, 5).equals(rawtxTopicBuffer)) {
     return false;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is a followup on https://github.com/dashevo/dashcore-node/pull/69, it's not only `rawtxlock` but also `rawtx` that is being sent as txbuffer from ZMQ socket. 
This PR modifies previous in order to encompass both of these cases.

## What was done?
- provided hotfix that abandon trying to parse such message. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

