### PR TITLE
feat: RPC call for getBestChainLock

### DIFF
--- a/lib/services/dashd.js
+++ b/lib/services/dashd.js
@@ -185,6 +185,7 @@ Dash.prototype.getAPIMethods = function() {
     ['getBlockOverview', this, this.getBlockOverview, 1],
     ['getBlockHashesByTimestamp', this, this.getBlockHashesByTimestamp, 2],
     ['getBestBlockHash', this, this.getBestBlockHash, 0],
+    ['getBestChainLock', this, this.getBestChainLock, 0],
     ['getSpentInfo', this, this.getSpentInfo, 1],
     ['getMNList', this, this.getMNList, 1],
     ['getInfo', this, this.getInfo, 0],
@@ -2707,6 +2708,21 @@ Dash.prototype.getBestBlockHash = function(callback) {
     callback(null, response.result);
   });
 };
+
+/**
+ * Will get the block hash and height of the best chainlock.
+ * @param {Function} callback
+ */
+Dash.prototype.getBestChainLock = function (callback) {
+  var self = this;
+  this.client.getBestChainLock(function (err, response) {
+    if (err) {
+      return callback(self._wrapRPCError(err));
+    }
+    callback(null, response.result);
+  });
+};
+
 
 /**
  * Will give the txid and inputIndex that spent an output

--- a/package-lock.json
+++ b/package-lock.json
@@ -149,9 +149,9 @@
       }
     },
     "@dashevo/dashd-rpc": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-2.0.2.tgz",
-      "integrity": "sha512-fbD+40fzVLHGliRoNd8kGqkoUkGeEKZOo2X5OhEkrUxDoGXTWRL4u0R/e72l57Oj8Aqfwh2S4dQ5gB7zu3AFhA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-2.1.0.tgz",
+      "integrity": "sha512-5+cKTL0JC5irQjr479ovucZ5KS5Zv4+0nIATnKDnU3giHAVQlIDqrLnHbs/8TNEk9XXx4ZtUafhMOxXgwo2W2Q==",
       "requires": {
         "async": "^3.2.0",
         "bluebird": "^3.7.2"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "dependencies": {
     "@dashevo/dashcore-lib": "^0.19.12",
-    "@dashevo/dashd-rpc": "^2.0.2",
+    "@dashevo/dashd-rpc": "^2.1.0",
     "async": "^2.6.1",
     "body-parser": "^1.18.3",
     "colors": "^1.3.3",

--- a/test/services/dashd.unit.js
+++ b/test/services/dashd.unit.js
@@ -105,7 +105,7 @@ describe('Dash Service', function() {
       var dashd = new DashService(baseConfig);
       var methods = dashd.getAPIMethods();
       should.exist(methods);
-      methods.length.should.equal(24);
+      methods.length.should.equal(25);
     });
   });
 
@@ -5019,6 +5019,54 @@ describe('Dash Service', function() {
         }
         should.exist(hash);
         hash.should.equal('besthash');
+        done();
+      });
+    });
+  });
+
+  describe('#getBestChainLock', function () {
+    it('will give rpc error', function (done) {
+      var dashd = new DashService(baseConfig);
+      var getBestChainLock = sinon.stub().callsArgWith(0, { message: 'error', code: -32603 });
+      dashd.nodes.push({
+        client: {
+          getBestChainLock: getBestChainLock
+        }
+      });
+      dashd.getBestChainLock(function (err) {
+        should.exist(err);
+        err.should.be.an.instanceof(errors.RPCError);
+        done();
+      });
+    });
+    it('will call getBestChainLock and give result', function (done) {
+      var dashd = new DashService(baseConfig);
+      var getBestChainLock = sinon.stub().callsArgWith(0, null, {
+        result: {
+          bestchainlock: {
+            blockhash: '20b6cc0600037171b8bb634bbd04ea754945be44db8d9199b74798f1abdb382d',
+            height: 151,
+            known_block: true
+          }
+        }
+      });
+      dashd.nodes.push({
+        client: {
+          getBestChainLock: getBestChainLock
+        }
+      });
+      dashd.getBestChainLock(function (err, result) {
+        if (err) {
+          return done(err);
+        }
+        should.exist(result);
+        result.should.deep.equal({
+          bestchainlock: {
+            blockhash: '20b6cc0600037171b8bb634bbd04ea754945be44db8d9199b74798f1abdb382d',
+            height: 151,
+            known_block: true
+          }
+        });
         done();
       });
     });


### PR DESCRIPTION
This PR brings adds a `getBestChainLock` method (calling `getbestchainlock` RPC on the node) in dashd service which will be used by insight-api via the `/status` endpoint.
PRs to integrate this feature in insight-api and insight-ui will be created shortly. 

Tests for this method (similar to other similar methods tests) are included.

No breaking changes introduced.