### PR TITLE
chore: bump version to 6.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashcore-node",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@dashevo/dashcore-node",
   "description": "Full node with extended capabilities using Dashcore and Dash Core (dashd)",
   "author": "BitPay <dev@bitpay.com>",
-  "version": "6.2.2",
+  "version": "6.2.3",
   "main": "./index.js",
   "repository": "git://github.com/dashevo/dashcore-node.git",
   "homepage": "https://github.com/dashevo/dashcore-node",


### PR DESCRIPTION
This PR:
- bumps the version to 6.2.3 for release