### PR TITLE
fix: maxFeeRate equals to minimum possible fee

### DIFF
--- a/lib/services/dashd.js
+++ b/lib/services/dashd.js
@@ -2080,7 +2080,7 @@ Dash.prototype.estimateFee = function(blocks, callback) {
  */
 Dash.prototype.sendTransaction = function(tx, options, callback) {
   var self = this;
-  var maxFeeRate = 0.00001000; // duff/kB (typically less than 1000)
+  var maxFeeRate = 0.00015000; // duff/kB (typically 1000)
   var isInstantSend = false;
   if (_.isFunction(options) && _.isUndefined(callback)) {
     callback = options;

--- a/lib/services/dashd.js
+++ b/lib/services/dashd.js
@@ -2090,7 +2090,7 @@ Dash.prototype.sendTransaction = function(tx, options, callback) {
     }
     if(options.hasOwnProperty('allowAbsurdFees')){
       console.warn(`the boolean 'allowAbsurdFees' has been replaced by the int 'maxFeeRate'`);
-      if(false === options.allowAbsurdFees) {
+      if(true === options.allowAbsurdFees) {
         maxFeeRate = 0; // unlimited
       }
     }


### PR DESCRIPTION
Follow up to https://github.com/dashevo/dashcore-node/pull/90

- fixes incorrect boolean comparison
- minimum fee should not be the maximum fee (other code uses 15x minimum)

See also:
- https://github.com/dashevo/dashd-rpc/pull/50
- https://github.com/dashevo/insight-api/pull/90