### PR TITLE
Bump to v7 and for DashCore v18 deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dashevo/dashcore-node",
-  "version": "6.3.0",
+  "version": "18.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dashevo/dashcore-node",
-      "version": "6.3.0",
+      "version": "18.0.0",
       "license": "MIT",
       "dependencies": {
         "@dashevo/dashcore-lib": "~0.19.41",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dashevo/dashcore-lib": "~0.19.41",
-        "@dashevo/dashd-rpc": "^2.4.2",
+        "@dashevo/dashd-rpc": "^18.0.1",
         "async": "^2.6.1",
         "body-parser": "^1.18.3",
         "colors": "^1.3.3",
@@ -78,11 +78,11 @@
       }
     },
     "node_modules/@dashevo/dashd-rpc": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-2.4.2.tgz",
-      "integrity": "sha512-gb2+g8zEkj1jk5UfWF/94sO4U8MxmfBoE0RFXAOnrmKkPIA0CeOoDf0Ep26+vM//UjjdxjHmXFVNel2z6azUUA==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-18.0.1.tgz",
+      "integrity": "sha512-RRpsoZWP/pmu/9t9RlYvZtdICYN43a/a8Nz0P1duav5+4ZcRCnwK6NkcPdYg5kCno1gRIj3D3kVLHPxpzPKc5w==",
       "dependencies": {
-        "async": "^3.2.0",
+        "async": "^3.2.4",
         "bluebird": "^3.7.2"
       }
     },
@@ -6263,11 +6263,11 @@
       }
     },
     "@dashevo/dashd-rpc": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-2.4.2.tgz",
-      "integrity": "sha512-gb2+g8zEkj1jk5UfWF/94sO4U8MxmfBoE0RFXAOnrmKkPIA0CeOoDf0Ep26+vM//UjjdxjHmXFVNel2z6azUUA==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dashd-rpc/-/dashd-rpc-18.0.1.tgz",
+      "integrity": "sha512-RRpsoZWP/pmu/9t9RlYvZtdICYN43a/a8Nz0P1duav5+4ZcRCnwK6NkcPdYg5kCno1gRIj3D3kVLHPxpzPKc5w==",
       "requires": {
-        "async": "^3.2.0",
+        "async": "^3.2.4",
         "bluebird": "^3.7.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "@dashevo/dashcore-lib": "~0.19.41",
-    "@dashevo/dashd-rpc": "^2.4.2",
+    "@dashevo/dashd-rpc": "^18.0.1",
     "async": "^2.6.1",
     "body-parser": "^1.18.3",
     "colors": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@dashevo/dashcore-node",
   "description": "Full node with extended capabilities using Dashcore and Dash Core (dashd)",
   "author": "BitPay <dev@bitpay.com>",
-  "version": "6.3.0",
+  "version": "18.0.0",
   "main": "./index.js",
   "repository": "git://github.com/dashevo/dashcore-node.git",
   "homepage": "https://github.com/dashevo/dashcore-node",


### PR DESCRIPTION
DashCore v18 had some breaking changes. Let's sync to v18 to signify that any new breaking changes are actually patches to fix for v18.

See also:
- https://github.com/dashevo/dashd-rpc/pull/51
- https://github.com/dashevo/insight-api/pull/91