### PR TITLE
fix: only silence warnings (not fatal errors)

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '18'
 
       - name: Enable NPM cache
         uses: actions/cache@v2

--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,7 @@
   "freeze": true,
   "immed": true,
   "indent": 2,
-  "latedef": true,
+  "latedef": "nofunc",
   "newcap": false,
   "noarg": true,
   "node": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,11 +1,11 @@
 {
+  "esversion": 11,
   "bitwise": false,
   "browser": true,
   "camelcase": false,
   "curly": true,
   "devel": false,
   "eqeqeq": true,
-  "esnext": true,
   "freeze": true,
   "immed": true,
   "indent": 2,

--- a/lib/services/dashd.js
+++ b/lib/services/dashd.js
@@ -21,6 +21,17 @@ var utils = require('../utils');
 var Service = require('../service');
 var rawtxTopicBuffer = new Buffer('7261777478', 'hex');
 var rawtxlockTopicBuffer = new Buffer('72617774786c6f636b', 'hex');
+
+function isNonFatalError(err) {
+  if (err.code === Dash.E_RPC_IN_WARMUP) {
+    log.warn(err.message);
+    return true;
+  }
+
+  // will throw instead of retrying
+  return false;
+}
+
 /**
  * Provides a friendly event driven API to dashd in Node.js. Manages starting and
  * stopping dashd as a child process for application support, as well as connecting
@@ -77,6 +88,7 @@ Dash.DEFAULT_SPAWN_RESTART_TIME = 5000;
 Dash.DEFAULT_SPAWN_STOP_TIME = 10000;
 Dash.DEFAULT_TRY_ALL_INTERVAL = 1000;
 Dash.DEFAULT_REINDEX_INTERVAL = 10000;
+Dash.DEFAULT_START_RETRY_TIMES = 60;
 Dash.DEFAULT_START_RETRY_INTERVAL = 5000;
 Dash.DEFAULT_TIP_UPDATE_INTERVAL = 15000;
 Dash.DEFAULT_TRANSACTION_CONCURRENCY = 5;
@@ -96,6 +108,7 @@ Dash.DEFAULT_CONFIG_SETTINGS = {
   rpcpassword: 'local321',
   uacomment: 'dashcore'
 };
+Dash.E_RPC_IN_WARMUP = -28;
 
 Dash.prototype._initDefaults = function(options) {
   /* jshint maxcomplexity: 15 */
@@ -113,6 +126,7 @@ Dash.prototype._initDefaults = function(options) {
 
   // try all interval
   this.tryAllInterval = options.tryAllInterval || Dash.DEFAULT_TRY_ALL_INTERVAL;
+  this.startRetryTimes = options.startRetryTimes || Dash.DEFAULT_START_RETRY_TIMES;
   this.startRetryInterval = options.startRetryInterval || Dash.DEFAULT_START_RETRY_INTERVAL;
 
   // rpc limits
@@ -856,10 +870,7 @@ Dash.prototype._checkReindex = function(node, callback) {
 Dash.prototype._loadTipFromNode = function(node, callback) {
   var self = this;
   node.client.getBestBlockHash(function(err, response) {
-    if (err && err.code === -28) {
-      log.warn(err.message);
-      return callback(self._wrapRPCError(err));
-    } else if (err) {
+    if (err) {
       return callback(self._wrapRPCError(err));
     }
     node.client.getBlock(response.result, function(err, response) {
@@ -963,7 +974,12 @@ Dash.prototype._spawnChildProcess = function(callback) {
 
     var exitShutdown = false;
 
-    async.retry({times: 60, interval: self.startRetryInterval}, function(done) {
+    var retryOpts = {
+      times: self.startRetryTimes,
+      interval: self.startRetryInterval,
+      errorFilter: isNonFatalError,
+    };
+    async.retry(retryOpts, function (done) {
       if (self.node.stopping) {
         exitShutdown = true;
         return done();
@@ -1008,7 +1024,12 @@ Dash.prototype._connectProcess = function(config, callback) {
   var node = {};
   var exitShutdown = false;
 
-  async.retry({times: 60, interval: self.startRetryInterval}, function(done) {
+  var retryOpts = {
+    times: self.startRetryTimes,
+    interval: self.startRetryInterval,
+    errorFilter: isNonFatalError,
+  };
+  async.retry(retryOpts, function(done) {
     if (self.node.stopping) {
       exitShutdown = true;
       return done();


### PR DESCRIPTION
Perhaps due to a change in he behavior of `async.retry` or perhaps by some other means, all connection errors (except verifying block warnings) are silenced on startup.

This means that any input that guarantees permanent failure - such as a wrong password or hostname or ip address or port - will just "sit there" without any feedback to the user.

Very confusing.

This changes the behavior so that the warning is logged and then ignored, but unexpected and fatal errors will throw.

If there are other non-fatal errors, then they can be added to the `isNonFatalError` filter. 